### PR TITLE
Kickstart command fixes

### DIFF
--- a/cmd/kubectl-package/kickstartcmd/kickstart.go
+++ b/cmd/kubectl-package/kickstartcmd/kickstart.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type Kickstarter interface {
@@ -27,7 +28,7 @@ func NewCmd(kickstarter Kickstarter) *cobra.Command {
 		Short: cmdShort,
 		Long:  cmdLong,
 	}
-	opts.AddFlags(cmd)
+	opts.AddFlags(cmd.Flags())
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		msg, err := kickstarter.Kickstart(cmd.Context(), args[0], opts.Inputs)
@@ -46,11 +47,9 @@ type options struct {
 	Inputs []string
 }
 
-func (o *options) AddFlags(cmd *cobra.Command) {
-	flags := cmd.Flags()
-
+func (o *options) AddFlags(flags *pflag.FlagSet) {
 	const (
-		inputUse = "(Required) Files or urls to load objects from. " +
+		inputUse = "Files or urls to load objects from. " +
 			`Supports glob and "-" to read from stdin. Can be supplied multiple times.`
 	)
 
@@ -61,8 +60,4 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		nil,
 		inputUse,
 	)
-
-	if err := cmd.MarkFlagRequired("filename"); err != nil {
-		panic(`Programmer error: Unknown flag "filename".`)
-	}
 }

--- a/internal/packages/internal/packagekickstart/errors.go
+++ b/internal/packages/internal/packagekickstart/errors.go
@@ -1,0 +1,56 @@
+package packagekickstart
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+type ObjectIsMissingMetadataError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectIsMissingMetadataError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("object is missing metadata: '%s'", b)
+}
+
+type ObjectIsMissingNameError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectIsMissingNameError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("object is missing name: '%s'", b)
+}
+
+type ObjectIsDuplicateError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectIsDuplicateError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("duplicate object: '%s'", b)
+}
+
+type ObjectHasInvalidAPIVersionError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectHasInvalidAPIVersionError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("object has invalid apiVersion: '%s'", b)
+}

--- a/internal/packages/internal/packagekickstart/meta.go
+++ b/internal/packages/internal/packagekickstart/meta.go
@@ -24,7 +24,7 @@ func parseObjectMeta(obj unstructured.Unstructured) (namespacedName, error) {
 	if !ok {
 		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
 	}
-	// Validate that .metdata is a map.
+	// Validate that .metadata is a map.
 	metamap, ok := metadata.(map[string]interface{})
 	if !ok {
 		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
@@ -36,14 +36,7 @@ func parseObjectMeta(obj unstructured.Unstructured) (namespacedName, error) {
 		return namespacedName{}, &ObjectIsMissingNameError{obj}
 	}
 
-	namespace := obj.GetNamespace()
-	// Default empty namespace - this also happens for cluster-scoped GKs
-	// since there is no reliable way to look up the scope of a GK.
-	if namespace == "" {
-		namespace = "default"
-	}
-
-	escapedNamespace := escapeFilepathSeparator(namespace)
+	escapedNamespace := escapeFilepathSeparator(obj.GetNamespace())
 	escapedName := escapeFilepathSeparator(name)
 	return namespacedName{
 		namespace: escapedNamespace,

--- a/internal/packages/internal/packagekickstart/meta.go
+++ b/internal/packages/internal/packagekickstart/meta.go
@@ -1,0 +1,87 @@
+package packagekickstart
+
+import (
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type namespacedName struct {
+	namespace, name string
+}
+
+// Parses namespace and name from the given unstructured object.
+// The function:
+// - validatesthe existence of `.metadata` and that it is a map.
+// - defaults an empty `.metadata.namespace` to the string "default".
+// - validates that `.metadata.name` is not empty.
+// - escapes potential filepath separators in the results by passing them through `escapeFilepathSeparator()`
+// - returns namespace and name.
+func parseObjectMeta(obj unstructured.Unstructured) (namespacedName, error) {
+	metadata, ok := obj.Object["metadata"]
+	// Validate that .metadata exists.
+	if !ok {
+		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
+	}
+	// Validate that .metdata is a map.
+	metamap, ok := metadata.(map[string]interface{})
+	if !ok {
+		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
+	}
+
+	// Validate that .metadata.name exists, is a string and is not empty.
+	name, ok := metamap["name"].(string)
+	if !ok || name == "" {
+		return namespacedName{}, &ObjectIsMissingNameError{obj}
+	}
+
+	namespace := obj.GetNamespace()
+	// Default empty namespace - this also happens for cluster-scoped GKs
+	// since there is no reliable way to look up the scope of a GK.
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	escapedNamespace := escapeFilepathSeparator(namespace)
+	escapedName := escapeFilepathSeparator(name)
+	return namespacedName{
+		namespace: escapedNamespace,
+		name:      escapedName,
+	}, nil
+}
+
+// Replace filepath separators (`/` or `\`) with dashes (`-`), to prevent
+// the kickstart from creating files outside of the package directory for
+// malformed object namespaces or names in the input.
+func escapeFilepathSeparator(input string) string {
+	return strings.ReplaceAll(input, string(filepath.Separator), "-")
+}
+
+type groupKind struct {
+	group, kind string
+}
+
+// Parses group and kind from the given unstructured object.
+// This function:
+//   - validates that the apiVersion in the object contains a version.
+//   - does NOT validate that the object contains a kind because this already fails the unmarshalling phase.
+//     (There is be a regression test for that case!)
+//   - defaults an empty apiGroup to the string "core".
+func parseTypeMeta(obj unstructured.Unstructured) (groupKind, error) {
+	gvk := obj.GroupVersionKind()
+	if gvk.Version == "" {
+		return groupKind{}, &ObjectHasInvalidAPIVersionError{obj}
+	}
+
+	group := obj.GroupVersionKind().Group
+	// Expand core api group.
+	if group == "" {
+		group = "core"
+	}
+
+	return groupKind{
+		group: group,
+		kind:  obj.GetKind(),
+	}, nil
+}

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/duplicate-object.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/duplicate-object.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+  namespace: ns
+  labels:
+    foo: bar
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+  namespace: ns
+  labels:
+    foo: baz

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/metadata-is-string.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/metadata-is-string.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: foo

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-apiversion.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-apiversion.yaml
@@ -1,0 +1,4 @@
+kind: Secret
+metadata:
+  namespace: foo
+  name: bar

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-kind.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-kind.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+metadata:
+  namespace: foo
+  name: bar

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-metadata.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-metadata.yaml
@@ -1,0 +1,2 @@
+apiVersion: v1
+kind: ConfigMap

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-name.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-name.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: {}

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-namespace.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/same-name-different-namespace.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/same-name-different-namespace.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aaah
+  namespace: a
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aaah
+  namespace: b
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aaah
+  namespace: c


### PR DESCRIPTION
fixes to the kickstart-command PR


cmd/kubectl-package/kickstartcmd/kickstart.go:
- fix grammar in `cmdLong`
- replace flag validation with requiring the `-f` flag (because `-f ""` was not catched by manual validation logic) and the FlagNeedArgumentError was never actually instanciated

internal/cmd/kickstart/kickstart.go:
- Move creation of output package folder after successful kickstart so one can re-run the kickstart command when iterating on broken input without having to remove the package folder each time
- add a pre-flight check that checks if the folder (or a file with the same name) is already taken to prevent (potentially expensive) kickstarting logic from running
- remove `if reader == nil { return nil, nil }` from getInput because the reader should NEVER be nil in that place and if it is nil then the io.ReadAll call in the next line will (and should) panic instead of hiding the problem

internal/packages/internal/packagekickstart:
- validate input object metadata to be a map
- validate input object metadata to contain a name
- sanitize input object namespace and name so that they can't contain path separators to prevent output files from escaping the output pkgDir
- default input object namespaces to "default" if empty (this also happens for cluster-scoped object sadly, because i didn't find a solution to know about the scope for each possible gvk)
- build output filenames from the pattern `$namespace.$name.$group.$kind.yaml` to prevent overriding the same object in other namespaces and also the same kind in other apiGroups
- catch duplicate objects
- validate object "typeMeta" by enforcing that there is an apiVersion set
- default the core group to "core" for the filename pattern

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
